### PR TITLE
Ios module map

### DIFF
--- a/apps/demo-react-native/ios/src/RNTestModule.m
+++ b/apps/demo-react-native/ios/src/RNTestModule.m
@@ -4,7 +4,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(show:withResolver : (RCTPromiseResolveBlock)resolve withRejecter : (RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(show:(RCTPromiseResolveBlock)resolve withRejecter : (RCTPromiseRejectBlock)reject)
 {
   NSLog(@"Called RCT Method: show");
   resolve(@"show method invoked");


### PR DESCRIPTION
This PR now emits the JS method name.

The actual output:
```json
{"RNTestModule":{"show":{"j":"showWithRejecter","t":[1,14,15]}}}
```

Which is equivalent to this, but minified:
```js
{
  // The name registered into NativeModules.
  "RNTestModule":{
    // The method name as it'll be exported to React Native.
    "show":{
      // The name by which NativeScript exposes the Obj-C method to JS.
      "jsName": "showWithRejecter",
      // The types of the method signature, starting with the return type.
      "types": [
        RNObjcSerialisableType.void,
        RNObjcSerialisableType.RCTPromiseResolveBlock,
        RNObjcSerialisableType.RCTPromiseRejectBlock,
      ]
    }
  }
}
```